### PR TITLE
Add wiki mode and inline link parsing

### DIFF
--- a/src/lib/orgIdIndex.ts
+++ b/src/lib/orgIdIndex.ts
@@ -15,6 +15,7 @@ async function* walkOrgFiles(
 }
 
 export type OrgIdIndex = Map<string, FileSystemFileHandle>;
+export type OrgFilePathIndex = Map<string, FileSystemFileHandle>;
 
 export async function buildOrgIdIndex(dir: FileSystemDirectoryHandle): Promise<OrgIdIndex> {
 	const index: OrgIdIndex = new Map();
@@ -34,6 +35,16 @@ export async function buildOrgIdIndex(dir: FileSystemDirectoryHandle): Promise<O
 	return index;
 }
 
+export async function buildOrgFilePathIndex(
+	dir: FileSystemDirectoryHandle
+): Promise<OrgFilePathIndex> {
+	const index: OrgFilePathIndex = new Map();
+	for await (const { handle, path } of walkOrgFiles(dir)) {
+		index.set(path, handle);
+	}
+	return index;
+}
+
 export async function resolveIdLink(
 	index: OrgIdIndex,
 	id: string
@@ -42,4 +53,20 @@ export async function resolveIdLink(
 	if (!handle) return null;
 	const file = await handle.getFile();
 	return file.text();
+}
+
+export function resolveFilePath(
+	index: OrgFilePathIndex,
+	path: string
+): FileSystemFileHandle | null {
+	// Strip any in-file anchor like ::heading or ::*Heading
+	const cleaned = path.split('::')[0];
+	// Try direct match first (e.g. "roam/foo.org"), then basename fallback
+	const direct = index.get(cleaned);
+	if (direct) return direct;
+	const base = cleaned.split('/').pop() ?? cleaned;
+	for (const [p, h] of index) {
+		if (p === base || p.endsWith('/' + base)) return h;
+	}
+	return null;
 }

--- a/src/lib/orglink.svelte
+++ b/src/lib/orglink.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+	export let target: string;
+	export let description = '';
+
+	$: label = description || target;
+	$: isId = target.startsWith('id:');
+	$: isFile = target.startsWith('file:');
+
+	function dispatchBubbling(e: MouseEvent, name: string, detail: string) {
+		e.currentTarget?.dispatchEvent(new CustomEvent(name, { detail, bubbles: true }));
+	}
+</script>
+
+{#if isId}
+	<button
+		class="org-link id-link"
+		title={target}
+		on:click={(e) => dispatchBubbling(e, 'idnavigate', target.slice(3))}>{label}</button
+	>
+{:else if isFile}
+	<button
+		class="org-link file-link"
+		title={target}
+		on:click={(e) => dispatchBubbling(e, 'filenavigate', target.slice(5))}>{label}</button
+	>
+{:else}
+	<a class="org-link" href={target} title={target} target="_blank" rel="noopener">{label}</a>
+{/if}
+
+<style>
+	.org-link {
+		color: darkcyan;
+		text-decoration: underline;
+		cursor: pointer;
+	}
+
+	.org-link:hover {
+		color: teal;
+	}
+
+	button.org-link {
+		background: none;
+		border: none;
+		padding: 0;
+		font: inherit;
+	}
+</style>

--- a/src/lib/orgnodebody.svelte
+++ b/src/lib/orgnodebody.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import OrgNodeText from './orgnodetext.svelte';
+	import OrgLink from './orglink.svelte';
 	import {
 		type OrgBodyElement,
 		isText,
@@ -47,39 +48,7 @@
 		{:else if isSource(element)}
 			<pre><code>{element.text}</code></pre>
 		{:else if isLink(element)}
-			{#if element.target.startsWith('id:')}
-				<button
-					class="org-link id-link"
-					title={element.target}
-					on:click={(e) =>
-						e.currentTarget.dispatchEvent(
-							new CustomEvent('idnavigate', {
-								detail: element.target.slice(3),
-								bubbles: true
-							})
-						)}>{element.description}</button
-				>
-			{:else}
-				<a class="org-link" href={element.target} title={element.target}
-					>{element.description}</a
-				>
-			{/if}
+			<OrgLink target={element.target} description={element.description} />
 		{/if}
 	{/each}
 </div>
-
-<style>
-	.id-link {
-		color: darkcyan;
-		text-decoration: underline;
-		cursor: pointer;
-		background: none;
-		border: none;
-		padding: 0;
-		font: inherit;
-	}
-
-	.id-link:hover {
-		color: teal;
-	}
-</style>

--- a/src/lib/orgnodetext.svelte
+++ b/src/lib/orgnodetext.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { OrgText } from './types';
+	import OrgLink from './orglink.svelte';
 
 	export let text: OrgText;
 
@@ -11,27 +12,56 @@
 	// - Code, format: ~code~
 	// - Dates, format: <2021-01-01> or <2021-01-01 Fri>, <2021-01-01 Fri 12:00>, <2021-01-01 Fri 12:00-13:00>
 
-	const urlPattern = /(\b[a-zA-Z][a-zA-Z0-9+.-]*:\/\/[^\s)>\]]+)/g;
+	const orgLinkPattern = /\[\[([^\]]+)\](?:\[([^\]]+)\])?\]/g;
+	const urlPattern = /\b[a-zA-Z][a-zA-Z0-9+.-]*:\/\/[^\s)>\]]+/g;
 
-	type Segment = { text: string; url: boolean };
+	type TextSeg = { kind: 'text'; text: string };
+	type UrlSeg = { kind: 'url'; text: string };
+	type LinkSeg = { kind: 'link'; target: string; description: string };
+	type Segment = TextSeg | UrlSeg | LinkSeg;
 
-	$: segments = splitUrls(text.text);
+	$: segments = tokenize(text.text);
+
+	function tokenize(input: string): Segment[] {
+		const parts: Segment[] = [];
+		let lastIndex = 0;
+		for (const match of input.matchAll(orgLinkPattern)) {
+			if (match.index > lastIndex) {
+				parts.push(...splitUrls(input.slice(lastIndex, match.index)));
+			}
+			parts.push({ kind: 'link', target: match[1], description: match[2] ?? '' });
+			lastIndex = match.index + match[0].length;
+		}
+		if (lastIndex < input.length) {
+			parts.push(...splitUrls(input.slice(lastIndex)));
+		}
+		return parts;
+	}
 
 	function splitUrls(input: string): Segment[] {
 		const parts: Segment[] = [];
 		let lastIndex = 0;
 		for (const match of input.matchAll(urlPattern)) {
 			if (match.index > lastIndex) {
-				parts.push({ text: input.slice(lastIndex, match.index), url: false });
+				parts.push({ kind: 'text', text: input.slice(lastIndex, match.index) });
 			}
-			parts.push({ text: match[1], url: true });
+			parts.push({ kind: 'url', text: match[0] });
 			lastIndex = match.index + match[0].length;
 		}
 		if (lastIndex < input.length) {
-			parts.push({ text: input.slice(lastIndex), url: false });
+			parts.push({ kind: 'text', text: input.slice(lastIndex) });
 		}
 		return parts;
 	}
 </script>
 
-<p>{#each segments as seg}{#if seg.url}<a href={seg.text} target="_blank" rel="noopener">{seg.text}</a>{:else}{seg.text}{/if}{/each}</p>
+<p
+	>{#each segments as seg}{#if seg.kind === 'url'}<a
+				href={seg.text}
+				target="_blank"
+				rel="noopener">{seg.text}</a
+			>{:else if seg.kind === 'link'}<OrgLink
+				target={seg.target}
+				description={seg.description}
+			/>{:else}{seg.text}{/if}{/each}</p
+>

--- a/src/lib/wikiview.svelte
+++ b/src/lib/wikiview.svelte
@@ -1,0 +1,103 @@
+<script lang="ts">
+	import { createEventDispatcher } from 'svelte';
+	import type { OrgNode } from './types';
+	import OrgNodeBody from './orgnodebody.svelte';
+
+	export let orgtree: OrgNode;
+	export let orgFiles: FileSystemFileHandle[] = [];
+	export let showIndex = false;
+	export let level = 1;
+
+	const dispatch = createEventDispatcher<{ fileSelect: FileSystemFileHandle }>();
+	$: headingTag = 'h' + Math.min(level, 6);
+	$: stripName = (name: string) => name.replace(/\.org$/i, '');
+</script>
+
+{#if level === 1 && showIndex}
+	<div class="wikiview">
+		<h1>Wiki index</h1>
+		<ul class="wiki-index">
+			{#each orgFiles as handle}
+				<li>
+					<button class="index-link" on:click={() => dispatch('fileSelect', handle)}>
+						{stripName(handle.name)}
+					</button>
+				</li>
+			{/each}
+		</ul>
+	</div>
+{:else if level === 1}
+	<div class="wikiview">
+		<svelte:element this={headingTag} class={`wiki-heading ${orgtree.state}`}>
+			{orgtree.title}
+		</svelte:element>
+		{#if orgtree.body.length > 0}
+			<OrgNodeBody bodyparts={orgtree.body} />
+		{/if}
+		{#each orgtree.children as child}
+			<svelte:self orgtree={child} {orgFiles} showIndex={false} level={level + 1} on:fileSelect />
+		{/each}
+	</div>
+{:else}
+	<svelte:element this={headingTag} class={`wiki-heading ${orgtree.state}`}>
+		{orgtree.title}
+	</svelte:element>
+	{#if orgtree.body.length > 0}
+		<OrgNodeBody bodyparts={orgtree.body} />
+	{/if}
+	{#each orgtree.children as child}
+		<svelte:self orgtree={child} {orgFiles} showIndex={false} level={level + 1} on:fileSelect />
+	{/each}
+{/if}
+
+<style lang="scss">
+	.wikiview {
+		height: 100%;
+		overflow-y: auto;
+		max-width: 70ch;
+		margin: 0 auto;
+		padding: 2rem 1rem;
+		line-height: 1.5;
+	}
+
+	.wiki-heading {
+		margin: 1.2em 0 0.4em;
+
+		&.done {
+			text-decoration: line-through;
+			color: #888;
+		}
+
+		&.todo {
+			color: red;
+		}
+	}
+
+	.wiki-heading:first-child {
+		margin-top: 0;
+	}
+
+	.wiki-index {
+		list-style: none;
+		padding: 0;
+		margin: 1em 0;
+
+		li {
+			margin: 0.4em 0;
+		}
+	}
+
+	.index-link {
+		color: darkcyan;
+		text-decoration: underline;
+		cursor: pointer;
+		background: none;
+		border: none;
+		padding: 0;
+		font: inherit;
+
+		&:hover {
+			color: teal;
+		}
+	}
+</style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,8 +1,16 @@
 <script lang="ts">
 	import Mindmap from '$lib/mindmap.svelte';
 	import ThreadsView from '$lib/threadsview.svelte';
+	import WikiView from '$lib/wikiview.svelte';
 	import { orgTextToMindMap } from '$lib/orgTextToMindMap';
-	import { buildOrgIdIndex, resolveIdLink, type OrgIdIndex } from '$lib/orgIdIndex';
+	import {
+		buildOrgIdIndex,
+		buildOrgFilePathIndex,
+		resolveIdLink,
+		resolveFilePath,
+		type OrgIdIndex,
+		type OrgFilePathIndex
+	} from '$lib/orgIdIndex';
 
 	// Default URL for URL popup
 	let url: string | null =
@@ -10,6 +18,7 @@
 	let fileHandle: FileSystemFileHandle | null = null;
 	let orgDir: FileSystemDirectoryHandle | null = null;
 	let idIndex: OrgIdIndex | null = null;
+	let filePathIndex: OrgFilePathIndex | null = null;
 	let orgFiles: FileSystemFileHandle[] = [];
 
 	// Default map contains instructions for use
@@ -28,7 +37,7 @@
 *** Click on the gear icon in the top right corner
 *** Change the "Right only" to keep the root node on the left`;
 
-	let viewMode: 'mindmap' | 'threads' = 'mindmap';
+	let viewMode: 'wiki' | 'mindmap' | 'threads' = 'mindmap';
 	let reloadKey = 0;
 
 	$: orgTree = orgTextToMindMap(orgText);
@@ -75,6 +84,9 @@
 		}
 		orgFiles = files.sort((a, b) => a.name.localeCompare(b.name));
 		idIndex = await buildOrgIdIndex(orgDir);
+		filePathIndex = await buildOrgFilePathIndex(orgDir);
+		fileHandle = null;
+		viewMode = 'wiki';
 	}
 
 	async function selectOrgFile(handle: FileSystemFileHandle) {
@@ -84,14 +96,33 @@
 	}
 
 	function listenIdNavigate(node: HTMLElement) {
-		const handler = async (e: Event) => {
+		const idHandler = async (e: Event) => {
 			const id = (e as CustomEvent<string>).detail;
 			if (!idIndex) return;
 			const text = await resolveIdLink(idIndex, id);
-			if (text) orgText = text;
+			if (text) {
+				orgText = text;
+				viewMode = 'wiki';
+			}
 		};
-		node.addEventListener('idnavigate', handler);
-		return { destroy: () => node.removeEventListener('idnavigate', handler) };
+		const fileHandler = async (e: Event) => {
+			const path = (e as CustomEvent<string>).detail;
+			if (!filePathIndex) return;
+			const handle = resolveFilePath(filePathIndex, path);
+			if (!handle) return;
+			fileHandle = handle;
+			const file = await handle.getFile();
+			orgText = await file.text();
+			viewMode = 'wiki';
+		};
+		node.addEventListener('idnavigate', idHandler);
+		node.addEventListener('filenavigate', fileHandler);
+		return {
+			destroy: () => {
+				node.removeEventListener('idnavigate', idHandler);
+				node.removeEventListener('filenavigate', fileHandler);
+			}
+		};
 	}
 </script>
 
@@ -120,6 +151,9 @@
 		</select>
 	{/if}
 	<div class="view-toggle">
+		<label class:active={viewMode === 'wiki'}>
+			<input type="radio" bind:group={viewMode} value="wiki" /> Wiki
+		</label>
 		<label class:active={viewMode === 'mindmap'}>
 			<input type="radio" bind:group={viewMode} value="mindmap" /> Map
 		</label>
@@ -130,7 +164,14 @@
 </div>
 <div id="content" use:listenIdNavigate>
 	{#key reloadKey}
-		{#if viewMode === 'mindmap'}
+		{#if viewMode === 'wiki'}
+			<WikiView
+				orgtree={orgTree}
+				{orgFiles}
+				showIndex={fileHandle === null && orgFiles.length > 0}
+				on:fileSelect={(e) => selectOrgFile(e.detail)}
+			/>
+		{:else if viewMode === 'mindmap'}
 			<Mindmap orgtree={orgTree} />
 		{:else}
 			<ThreadsView orgtree={orgTree} {idIndex} />


### PR DESCRIPTION
## Summary
- Adds a **Wiki view** as a third option alongside Mindmap and Threads. Becomes the default when an org directory is opened and auto-activates on id: / file: link navigation. With no file selected, renders a clickable index of root-level files.
- Inline `[[target][description]]` links are now tokenized inside text (previously only standalone whole-line links were parsed). `id:`, `file:`, and URL targets share a single `OrgLink` renderer.
- `file:` links resolve relative paths against a new `OrgFilePathIndex` built from the open org dir.

Closes #6.

## Test plan
- [x] Open an org dir → Wiki view activates, file index renders.
- [x] Click an index entry → file opens in Wiki view.
- [x] Toggle Map / Threads / Wiki — all render correctly for the same file.
- [x] Click an inline `id:` link → target file loads and auto-switches to Wiki.
- [x] Click an inline `file:` link inside a list item → target file loads (direct match by relative path, basename fallback otherwise).
- [x] Open a single file (no folder): Wiki view renders the single file as a page (no index).
- [x] `npm run check`, `npm test -- --run` — pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)